### PR TITLE
Consolidate mdmpts, mdmlin, and mdmarea

### DIFF
--- a/R/grts.R
+++ b/R/grts.R
@@ -501,9 +501,9 @@ if(type.frame == "finite") {
 # Calculate mdm - inclusion probabilities
 
       if(design[[s]]$seltype == "Equal")
-         	sframe$mdm <- mdmpts(sframe$mdcaty, c(Equal=n.desired))
+         	sframe$mdm <- mdm(sframe$mdcaty, c(Equal=n.desired))
       else if(design[[s]]$seltype == "Unequal")
-         sframe$mdm <- mdmpts(sframe$mdcaty, n.desired)
+         sframe$mdm <- mdm(sframe$mdcaty, n.desired)
       else
          sframe$mdm <- n.desired * sframe$mdcaty / sum(sframe$mdcaty)
 
@@ -709,9 +709,9 @@ if(type.frame == "finite") {
 # Calculate mdm - inclusion probabilities
 
       if(design[[s]]$seltype == "Equal")
-         sframe$mdm <- mdmlin(sframe$len, sframe$mdcaty, c(Equal=n.desired))
+         sframe$mdm <- mdm(sframe$mdcaty, c(Equal=n.desired), sframe$len)
       else if(design[[s]]$seltype == "Unequal")
-         sframe$mdm <- mdmlin(sframe$len, sframe$mdcaty, n.desired)
+         sframe$mdm <- mdm(sframe$mdcaty, n.desired, sframe$len)
       else
          sframe$mdm <- n.desired * sframe$mdcaty /
                        sum(sframe$len * sframe$mdcaty)
@@ -878,9 +878,9 @@ if(type.frame == "finite") {
 # Calculate mdm - inclusion probabilities
 
       if(design[[s]]$seltype == "Equal")
-         sframe$mdm <- mdmarea(sframe$area_mdm, sframe$mdcaty, c(Equal=n.desired))
+         sframe$mdm <- mdm(sframe$mdcaty, c(Equal=n.desired), sframe$area_mdm)
       else if(design[[s]]$seltype == "Unequal")
-         sframe$mdm <- mdmarea(sframe$area, sframe$mdcaty, n.desired)
+         sframe$mdm <- mdm(sframe$mdcaty, n.desired, sframe$area)
       else
          sframe$mdm <- n.desired * sframe$mdcaty /
                        sum(sframe$area * sframe$mdcaty)

--- a/R/irs.R
+++ b/R/irs.R
@@ -413,9 +413,9 @@ if(type.frame == "finite") {
 # Calculate mdm - inclusion probabilities
 
       if(design[[s]]$seltype == "Equal")
-         	sframe$mdm <- mdmpts(sframe$mdcaty, c(Equal=n.desired))
+         	sframe$mdm <- mdm(sframe$mdcaty, c(Equal=n.desired))
       else if(design[[s]]$seltype == "Unequal")
-         sframe$mdm <- mdmpts(sframe$mdcaty, n.desired)
+         sframe$mdm <- mdm(sframe$mdcaty, n.desired)
       else
          sframe$mdm <- n.desired * sframe$mdcaty / sum(sframe$mdcaty)
 
@@ -619,9 +619,9 @@ if(type.frame == "finite") {
 # Calculate mdm - inclusion probabilities
 
       if(design[[s]]$seltype == "Equal")
-         sframe$mdm <- mdmlin(sframe$len, sframe$mdcaty, c(Equal=n.desired))
+         sframe$mdm <- mdm(sframe$mdcaty, c(Equal=n.desired), sframe$len)
       else if(design[[s]]$seltype == "Unequal")
-         sframe$mdm <- mdmlin(sframe$len, sframe$mdcaty, n.desired)
+         sframe$mdm <- mdm(sframe$mdcaty, n.desired, sframe$len)
       else
          sframe$mdm <- n.desired * sframe$mdcaty /
                        sum(sframe$len * sframe$mdcaty)
@@ -787,9 +787,9 @@ if(type.frame == "finite") {
 # Calculate mdm - inclusion probabilities
 
       if(design[[s]]$seltype == "Equal")
-         sframe$mdm <- mdmarea(sframe$area, sframe$mdcaty, c(Equal=n.desired))
+         sframe$mdm <- mdm(sframe$mdcaty, c(Equal=n.desired), sframe$area)
       else if(design[[s]]$seltype == "Unequal")
-         sframe$mdm <- mdmarea(sframe$area, sframe$mdcaty, n.desired)
+         sframe$mdm <- mdm(sframe$mdcaty, n.desired, sframe$area)
       else
          sframe$mdm <- n.desired * sframe$mdcaty /
                        sum(sframe$area * sframe$mdcaty)

--- a/R/mdm.R
+++ b/R/mdm.R
@@ -1,0 +1,35 @@
+################################################################################
+# File: mdm.r
+# Programmer: Tony Olsen, Jason Law
+# Date: June 6, 2020
+#
+#' Internal Function: GRTS Multipliers for Multi-Density Categories
+#' @param mdcaty Vector of multi-density category groups for each segment in
+#'   sample frame.
+#'
+#' @param n.desired Expected sample size for each category.  Row names must
+#'   match category names in mdcaty.
+#'   
+#' @param size  Vector of size measures for each feature in sample frame. Default
+#' is `NULL` for features with identical size measures (e.g., point features).
+#'
+#' @return Numeric vector of multipliers that is same length as size and mdcaty.
+#'
+#' @author Tony Olsen \email{Olsen.Tony@epa.gov}
+#'
+#' @export
+################################################################################
+
+mdm <- function(mdcaty, n.desired, size = NULL){
+  if(!is.factor(mdcaty)){
+    mdcaty <- as.factor(mdcaty)
+  }
+  nms       <- levels(mdcaty)
+  n.desired <- n.desired[nms]
+  if(is.null(size)){
+    gsum <- tabulate(mdcaty)
+  } else {
+    gsum <- vapply(split(size, mdcaty), sum, na.rm = T, FUN.VALUE = numeric(1))
+  }
+  return(unname(n.desired / gsum)[mdcaty])
+}


### PR DESCRIPTION
I've created a single mdm function which combines functionality of mdmpts, mdmlin, and mdmarea. This change consisted of adding an optional `size` argument which can be used to pass the feature length or area. The `mdm` function is about 1.5x faster for linear and area calculations and about 10x faster for point features. Changed references to mdmpts, mdmlin, and mdmarea in both grts and irs functions.

I rebuilt the package, ran the tests, and all passed with ok. I noticed, however, that these are more 'functional' tests rather than unit tests. Are unit tests for individual functions something that you would like to see implemented?